### PR TITLE
Added support for using postgres only for persistent grants

### DIFF
--- a/src/IdentityServer4.Postgresql/Extensions/IdentityServerBuilderExtensions.cs
+++ b/src/IdentityServer4.Postgresql/Extensions/IdentityServerBuilderExtensions.cs
@@ -79,6 +79,18 @@ namespace IdentityServer4.Contrib.Postgresql.Extensions
             builder.Services.AddSingleton<TokenCleanup>();
             return builder;
         }
+
+        public static IIdentityServerBuilder AddOperationalStore(this IIdentityServerBuilder builder, MartenOptions options, Action<TokenCleanupOptions> tokenCleanUpOptions = null)
+        {
+            builder.Services.AddScoped<IPersistedGrantStore, PersistedGrantStore>();
+            var tokenCleanupOptions = new TokenCleanupOptions();
+            tokenCleanUpOptions?.Invoke(tokenCleanupOptions);
+            builder.Services.AddSingleton(tokenCleanupOptions);
+            builder.Services.AddSingleton<TokenCleanup>();
+            ConfigureMarten(builder, options);
+            return builder;
+        }
+
         public static IApplicationBuilder UseIdentityServerTokenCleanup(this IApplicationBuilder app, IHostApplicationLifetime applicationLifetime)
         {
             var tokenCleanup = app.ApplicationServices.GetService<TokenCleanup>();


### PR DESCRIPTION
We have a project where we need to use postgres only for the persistent grant part (i.e. refresh tokens). This minor change allows us to do so. 